### PR TITLE
Query projects

### DIFF
--- a/social-media-research-database/app/api/search-experiments/route.ts
+++ b/social-media-research-database/app/api/search-experiments/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from "next/server";
+import { queryDB } from "@/app/api/utils";
+import { z } from "zod";
+
+const querySchema = z.object({
+  name: z.string().min(1, "Project name is required"),
+});
+
+type FieldResult = {
+  field_name: string;
+  result: string | null;
+};
+
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const name = url.searchParams.get("project_name");
+
+  const parsed = querySchema.safeParse({ name });
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid project name" }, { status: 400 });
+  }
+
+  try {
+    const query = `
+      SELECT
+        p.text,
+        p.datetime,
+        p.username,
+        p.social_name,
+        p.city,
+        p.region,
+        p.country,
+        p.likes,
+        p.dislikes,
+        p.has_multimedia,
+        fr.field_name,
+        fr.result
+      FROM FieldResult fr
+      LEFT JOIN Post p
+        ON fr.post_datetime = p.datetime 
+        AND fr.post_username = p.username 
+        AND fr.post_social_name = p.social_name
+      WHERE fr.project_name = ?;
+    `;
+
+    const results = await queryDB(query, [name]);
+
+    console.log("Results:", results);
+
+    const posts: {
+      datetime: string;
+      username: string;
+      social_name: string;
+      text: string | null;
+      city: string | null;
+      region: string | null;
+      country: string | null;
+      likes: number | null;
+      dislikes: number | null;
+      has_multimedia: boolean | null;
+      field_results: FieldResult[];
+    }[] = [];
+
+    const postMap: Record<string, typeof posts[0]> = {};
+
+    results.forEach((row: any) => {
+      const key = `${row.datetime}|${row.username}|${row.social_name}`;
+      if (!postMap[key]) {
+        postMap[key] = {
+          datetime: row.datetime,
+          username: row.username,
+          social_name: row.social_name,
+          text: row.text,
+          city: row.city,
+          region: row.region,
+          country: row.country,
+          likes: row.likes,
+          dislikes: row.dislikes,
+          has_multimedia: row.has_multimedia,
+          field_results: [],
+        };
+      }
+      postMap[key].field_results.push({
+        field_name: row.field_name,
+        result: row.result,
+      });
+    });
+
+    Object.values(postMap).forEach((post) => posts.push(post));
+
+    const statsQuery = `
+      SELECT
+        field_name,
+        COUNT(*) AS total,
+        COUNT(result) AS with_result
+      FROM FieldResult
+      WHERE project_name = ?
+      GROUP BY field_name;
+    `;
+
+    const statsResults = await queryDB(statsQuery, [name]);
+
+    const field_stats = statsResults.map((stat: any) => ({
+      field: stat.field_name,
+      percentage_with_value: (stat.with_result / stat.total) * 100,
+    }));
+
+    return NextResponse.json({
+      posts,
+      field_stats,
+    });
+  } catch (err: any) {
+    console.error("API ERROR:", err.message);
+    return NextResponse.json({ error: "Failed to fetch project field results" }, { status: 500 });
+  }
+}

--- a/social-media-research-database/app/search-experiments/page.tsx
+++ b/social-media-research-database/app/search-experiments/page.tsx
@@ -151,7 +151,11 @@ export default function SearchExperimentsPage() {
                                             <td>{new Date(post.datetime).toLocaleString()}</td>
                                             <td>{post.social_name}</td>
                                             <td>{post.username}</td>
-                                            <td>{post.text.length > 50 ? post.text.slice(0, 50) + "..." : post.text}</td>
+                                            <td>
+                                              {post.text && post.text.length > 50
+                                                ? post.text.slice(0, 50) + "..."
+                                                : post.text || ""}
+                                            </td>
                                             <td>{post.city}</td>
                                             <td>{post.region}</td>
                                             <td>{post.country}</td>

--- a/social-media-research-database/app/search-experiments/page.tsx
+++ b/social-media-research-database/app/search-experiments/page.tsx
@@ -12,13 +12,13 @@ type Post = {
     datetime: string;
     username: string;
     social_name: string;
-    text: string;
-    city: string;
-    region: string;
-    country: string;
-    likes: number;
-    dislikes: number;
-    has_multimedia: boolean;
+    text: string | null;
+    city: string | null;
+    region: string | null;
+    country: string | null;
+    likes: number | null;
+    dislikes: number | null;
+    has_multimedia: boolean | null;
     field_results: FieldResult[];
 };
 

--- a/social-media-research-database/app/search-experiments/page.tsx
+++ b/social-media-research-database/app/search-experiments/page.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Container, Row, Col, Form, Table, Alert } from "react-bootstrap";
+
+type FieldStats = {
+    field: string;
+    percentage_with_value: number;
+};
+
+type Post = {
+    datetime: string;
+    username: string;
+    social_name: string;
+    text: string;
+    city: string;
+    region: string;
+    country: string;
+    likes: number;
+    dislikes: number;
+    has_multimedia: boolean;
+    field_results: FieldResult[];
+};
+
+type FieldResult = {
+    field_name: string;
+    result: string | null;
+};
+
+type ExperimentSearchResult = {
+    posts: Post[];
+    field_stats: FieldStats[];
+};
+
+export default function SearchExperimentsPage() {
+    const [projectNames, setProjectNames] = useState<string[]>([]);
+    const [selectedProject, setSelectedProject] = useState("");
+    const [data, setData] = useState<ExperimentSearchResult | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        // Load project names
+        fetch("/api/projects")
+            .then((res) => res.json())
+            .then((projects) => {
+                const names = projects.map((p: any) => p.name);
+                setProjectNames(names);
+            })
+            .catch((err) => setError("Failed to load projects: " + err.message));
+    }, []);
+
+    useEffect(() => {
+        if (!selectedProject) return;
+
+        setError(null);
+        setData(null);
+
+        const url = `/api/search-experiments?project_name=${encodeURIComponent(selectedProject)}`;
+        fetch(url)
+            .then((res) => {
+                if (!res.ok) throw new Error("Failed to fetch search results");
+                return res.json();
+            })
+            .then((data: ExperimentSearchResult) => setData(data))
+            .catch((err) => setError(err.message));
+    }, [selectedProject]);
+
+    return (
+        <Container fluid>
+            <Row className="mb-4">
+                <Col>
+                    <h2 className="fw-bold">Search Experiments</h2>
+                </Col>
+            </Row>
+
+            <Row className="mb-4">
+                <Col md={6}>
+                    <Form.Group>
+                        <Form.Label>Select Project</Form.Label>
+                        <Form.Select
+                            value={selectedProject}
+                            onChange={(e) => setSelectedProject(e.target.value)}
+                        >
+                            <option value="">Choose a project</option>
+                            {projectNames.map((name) => (
+                                <option key={name} value={name}>
+                                    {name}
+                                </option>
+                            ))}
+                        </Form.Select>
+                    </Form.Group>
+                </Col>
+            </Row>
+
+            {error && (
+                <Row className="mb-4">
+                    <Col>
+                        <Alert variant="danger">{error}</Alert>
+                    </Col>
+                </Row>
+            )}
+
+            {data && (
+                <>
+                    <Row className="mb-4">
+                        <Col>
+                            <h4 className="fw-semibold">Field Coverage</h4>
+                            <Table bordered hover responsive>
+                                <thead className="table-secondary">
+                                    <tr>
+                                        <th>Field</th>
+                                        <th>% Posts With Value</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {data.field_stats.map((stat) => (
+                                        <tr key={stat.field}>
+                                            <td>{stat.field}</td>
+                                            <td>{stat.percentage_with_value.toFixed(1)}%</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Table>
+                        </Col>
+                    </Row>
+
+                    <Row>
+                        <Col>
+                            <h4 className="fw-semibold">Posts</h4>
+                            <Table bordered hover responsive>
+                                <thead className="table-dark">
+                                    <tr>
+                                        <th>Datetime</th>
+                                        <th>Platform</th>
+                                        <th>Username</th>
+                                        <th>Text</th>
+                                        <th>City</th>
+                                        <th>Region</th>
+                                        <th>Country</th>
+                                        <th>Likes</th>
+                                        <th>Dislikes</th>
+                                        <th>Has Multimedia</th>
+                                        {data.field_stats.map((stat) => (
+                                            <th key={stat.field}>{stat.field}</th>
+                                        ))}
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {data.posts.map((post, idx) => (
+                                        <tr key={`${post.datetime}-${post.username}-${post.social_name}-${idx}`}>
+                                            <td>{new Date(post.datetime).toLocaleString()}</td>
+                                            <td>{post.social_name}</td>
+                                            <td>{post.username}</td>
+                                            <td>{post.text.length > 50 ? post.text.slice(0, 50) + "..." : post.text}</td>
+                                            <td>{post.city}</td>
+                                            <td>{post.region}</td>
+                                            <td>{post.country}</td>
+                                            <td>{post.likes}</td>
+                                            <td>{post.dislikes}</td>
+                                            <td>{post.has_multimedia ? "Yes" : "No"}</td>
+                                            {data.field_stats.map((stat) => {
+                                                const match = post.field_results.find(
+                                                    (r) => r.field_name === stat.field
+                                                );
+                                                return <td key={stat.field}>{match?.result ?? "—"}</td>;
+                                            })}
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Table>
+                        </Col>
+                    </Row>
+                </>
+            )}
+        </Container>
+    );
+}

--- a/social-media-research-database/instrumentation.ts
+++ b/social-media-research-database/instrumentation.ts
@@ -154,7 +154,11 @@ export const tables: Record<string, TableDefinition> = {
                 ['Cat Sentiment Analysis :3', '2015-03-14 09:26:53', 'jdoe2', 'Twitter'],
                 ['Disinformation Analyzer', '2015-03-14 09:26:53', 'jdoe2', 'Twitter'],
                 ['Disinformation Analyzer', '2025-05-01 07:15:28', 'linda99', 'LinkedIn'],
-                
+                ['Disinformation Analyzer', '2025-05-01 07:16:35', 'mydogisthebest', 'Twitter'],
+                ['Mu Alpha Theta Pi Project', '2015-03-14 09:26:55', 'therealjdoe2', 'TikTok'],
+                ['Mu Alpha Theta Pi Project', '2015-03-14 09:26:53', 'jdoe2', 'Twitter'],
+                ['Cat Sentiment Analysis :3', '2024-12-31 15:00:05+00:00', 'iheartmycat', 'Instagram'],
+                ['Cat Sentiment Analysis :3', '2025-05-01 07:16:35', 'mydogisthebest', 'Twitter']
             ],
         },
     },
@@ -169,7 +173,7 @@ export const tables: Record<string, TableDefinition> = {
                 result TEXT,
                 PRIMARY KEY (field_name, project_name, post_datetime, post_username, post_social_name),
                 FOREIGN KEY (field_name, project_name) REFERENCES field(name, project_name) ON DELETE CASCADE,
-                FOREIGN KEY (post_datetime, post_username, post_social_name) REFERENCES post(datetime, username, social_name) ON DELETE CASCADE
+                FOREIGN KEY (project_name, post_datetime, post_username, post_social_name) REFERENCES project_post(project_name, datetime, username, social_name) ON DELETE CASCADE
             )
         `,
         demoData: {


### PR DESCRIPTION
You can now query experiments with this.
I think we may be missing a way to enter field results. I thought the code had a problem with not retrieving some of the fields, but I realized that they had no associated results. I tried to add some to test, but I couldn't find a way through the GUI.
This should work even in the special case that there are no field results for a field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new page for viewing social media research experiment data, including project selection and detailed post results.
  - Added tables displaying field coverage statistics and post details with dynamic columns based on project fields.
  - Implemented real-time data fetching and error handling for improved user experience.
  - Enhanced dataset with additional social media posts across multiple projects for richer analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->